### PR TITLE
user nameカラム一意設定 #26

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   before_save { self.email.downcase! }
 
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :name, presence: true, length: { maximum: 30 }, uniqueness: true
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
                     uniqueness: { case_sensitive: false }


### PR DESCRIPTION
why
グループ化の際にユーザを区別できるようにするため

what
Userモデルに一意のバリデーションを設定