### PR TITLE
group_usersテーブルにカラム追加 #28

### DIFF
--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,4 +1,6 @@
 class GroupUser < ApplicationRecord
+  validates :permission, presence: true
+
   belongs_to :user
   belongs_to :group
 end

--- a/db/migrate/20200603044904_add_permission_to_group_users.rb
+++ b/db/migrate/20200603044904_add_permission_to_group_users.rb
@@ -1,0 +1,5 @@
+class AddPermissionToGroupUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :group_users, :permission, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_034715) do
+ActiveRecord::Schema.define(version: 2020_06_03_044904) do
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "permission", default: false, null: false
     t.index ["group_id"], name: "index_group_users_on_group_id"
     t.index ["user_id"], name: "index_group_users_on_user_id"
   end


### PR DESCRIPTION
why
ユーザのグループ参加承認機能を設計に追加。それによりテーブル設計変更し、必要となったため。

what
migrationを実行し、カラムを追加。