### PR TITLE
招待ユーザヘッダー表示 #48

### DIFF
--- a/app/controllers/group_users_controller.rb
+++ b/app/controllers/group_users_controller.rb
@@ -6,6 +6,10 @@ class GroupUsersController < ApplicationController
     redirect_to group_url(group_user.group_id)
   end
 
+  def invite
+    @group_user = GroupUser.find_by(id: params[:id])
+  end
+
   private
 
   def group_user_params

--- a/app/helpers/group_users_helper.rb
+++ b/app/helpers/group_users_helper.rb
@@ -1,0 +1,6 @@
+module GroupUsersHelper
+  # 招待済み、且つ承認していないgroup_usersレコードを取得
+  def invited_groups
+    @invited_groups = current_user.group_users.where(permission: false)
+  end
+end

--- a/app/views/group_users/invite.html.erb
+++ b/app/views/group_users/invite.html.erb
@@ -1,0 +1,1 @@
+<h3>"<%= @group_user.group.name %>" から招待されています</h3>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,6 +4,11 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
       <ul class="navbar-nav">
         <% if logged_in? %>
+          <% if invited_groups %>
+            <% invited_groups.each do |invited_group| %>
+              <li class="nav-item"><%= link_to "#{invited_group.group.name}からの招待", invite_group_user_path(invited_group), class: 'nav-link' %></li>
+            <% end %>
+          <% end %>
           <li class="nav-item"><%= link_to '新規グループ作成', new_group_path, class: 'nav-link' %></li>
           <li class="nav-item"><%= link_to 'ユーザ詳細', current_user, class: 'nav-link' %></li>
           <li class="nav-item"><%= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link' %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,16 @@ Rails.application.routes.draw do
 
   get 'signup', to: 'users#new'
   resources :users, only: [:create, :show, :edit, :update]
+
   resources :groups, only: [:new, :create, :show, :edit, :update] do
     member do
       get :search_user
     end
   end
-  resources :group_users, only: [:create, :destroy]
+
+  resources :group_users, only: [:create, :destroy] do
+    member do
+      get :invite
+    end
+  end
 end


### PR DESCRIPTION
why
グループ化機能実装において必要なため

what
コントローラ、ヘッダー、ルーティングを編集