### PR TITLE
トップページ表示を変更 #54

### DIFF
--- a/app/helpers/group_users_helper.rb
+++ b/app/helpers/group_users_helper.rb
@@ -4,11 +4,9 @@ module GroupUsersHelper
     @unpermit_group_users = user.group_users.where(permission: false)
   end
 
-  # group_userレコードのpermission:true or false を判定するメソッド
+  # group_userレコードのpermission:true or false を判定
   def permitted_group_user?(user, group)
-    # userが所属するgroupの中から、groupのidと同じレコードのみをgroup_usersとして取得
     group_user = user.group_users.find_by(group_id: group.id)
-    # そのレコードのpermissionの値を返す(true or false)
-    group_user.permission
+    group_user.permission # permissionの値を返す(true or false)
   end
 end

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -1,11 +1,18 @@
 <% if logged_in? %>
   <h3>"<%= current_user.name %>"さん 1日1回大切な人に感謝を伝えましょう</h3>
   <% @groups.each do |group| %>
-    <div class="card mb-4">
-      <h4 class="card-header text-center text-white bg-dark">グループ名: <%= link_to "#{group.name}", group, class: 'text-white' %></h4>
-      <div class="card-body">
+    <% if permitted_group_user?(current_user, group) %> <!--参加済みグループのみを表示!-->
+      <div class="card mb-4">
+        <h4 class="card-header text-center text-white bg-dark">グループ名: <%= link_to "#{group.name}", group, class: 'text-white' %></h4>
+        <div class="card-body">
+          <% group.users.each do |user| %>
+            <% if current_user != user && permitted_group_user?(user, group) %> <!--ログインユーザでない 且つ 参加済みユーザのみを表示 !-->
+              <p>"<%= user.name %>" さんに今日も感謝を伝えよう</p>
+            <% end %>
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <%= paginate @groups %>
 


### PR DESCRIPTION
why
感謝を伝える機能実装のために必要な表示であるため

what
・ログインユーザの所属グループのみを表示
・上記グループのログインユーザでない且つ、参加済みユーザのみを表示