### PR TITLE
#25 を修正 groups_usersテーブル重複保存不可設定追加 #55

### DIFF
--- a/db/migrate/20200602034715_create_group_users.rb
+++ b/db/migrate/20200602034715_create_group_users.rb
@@ -3,8 +3,10 @@ class CreateGroupUsers < ActiveRecord::Migration[5.2]
     create_table :group_users do |t|
       t.references :user, foreign_key: true, null: false
       t.references :group, foreign_key: true, null: false
+      t.boolean :permission, default: false, null: false
 
       t.timestamps
+      t.index [:user_id, :group_id], unique: true
     end
   end
 end

--- a/db/migrate/20200603044904_add_permission_to_group_users.rb
+++ b/db/migrate/20200603044904_add_permission_to_group_users.rb
@@ -1,5 +1,0 @@
-class AddPermissionToGroupUsers < ActiveRecord::Migration[5.2]
-  def change
-    add_column :group_users, :permission, :boolean, default: false, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_03_044904) do
+ActiveRecord::Schema.define(version: 2020_06_02_034715) do
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
+    t.boolean "permission", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "permission", default: false, null: false
     t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id", "group_id"], name: "index_group_users_on_user_id_and_group_id", unique: true
     t.index ["user_id"], name: "index_group_users_on_user_id"
   end
 


### PR DESCRIPTION
why
user_idとgroup_idが同一セットでの保存はアプリの仕様的にありえてはいけないため。

what
migration をrollback しmigration ファイル修正後、migration を再度実行
