### PR TITLE
同一ユーザへの感謝登録の動作改善 #84

### DIFF
--- a/app/helpers/thanks_helper.rb
+++ b/app/helpers/thanks_helper.rb
@@ -1,8 +1,8 @@
 module ThanksHelper
 
-  # userに対してその日のthankがあるかどうか確認
-  def thank_today(user, thanks)
-    thanks_to_receiver = thanks.where(receiver_id: user.id) # thankを受けたuserのthanksに絞り込み
+  # group内でuserに対してその日のthankがあるかどうか確認
+  def thank_today(thanks, user, group)
+    thanks_to_receiver = thanks.where(receiver_id: user.id, group_id: group.id) # 該当group内でthankを受けたuserのthanksに絞り込み
     thank_days = []
     thanks_to_receiver.each do |thank|
       thank_date = I18n.l thank.created_at

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -8,7 +8,7 @@
           <% group.users.each do |user| %>
             <% if current_user != user && permitted_group_user?(user, group) %> <!-- ログインユーザでない 且つ 参加済みユーザのみを表示 !-->
               
-              <% if thank_today(user, @thanks) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
+              <% if thank_today(@thanks, user, group) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
                 <p><%= user.name %>さんに感謝を伝えました <%= link_to '元に戻す', thank_path(@today_thank), method: :delete, class: 'btn btn-secondary btn-md' %></p>
               <% else %>
 


### PR DESCRIPTION
why
異なるグループの同一ユーザに対する感謝データも含めて感謝登録、可能、不可能が分岐する仕様になっていたため。

what
thanksヘルパーの `thank_today` メソッドを修正し、合わせてビューも修正。