### PR TITLE
#69 を修正 感謝登録データ保存時に制約を付加 #80

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -3,13 +3,13 @@ class ThanksController < ApplicationController
   def create
     @thank = current_user.thanks.build(thank_params)
 
-    if @thank.save
+    if @thank.tell_thank(current_user, thank_params[:receiver_id], thank_params[:group_id])
       flash[:success] = '感謝を登録しました'
       redirect_to root_url
     else
       flash.now[:danger] = '感謝の登録に失敗しました'
       @groups = current_user.groups.order(id: :desc).page(params[:page]).per(5)
-      @thanks = current_user.thanks # テスト用
+      @thanks = current_user.thanks.where.not(created_at: nil)
       render 'toppages/index'
     end
   end

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -4,6 +4,21 @@ class Thank < ApplicationRecord
   belongs_to :receiver, class_name: 'User'
   belongs_to :group
 
+  # thank登録
+  def tell_thank(current_user, receiver_id, group_id)
+    thanks_to_receiver = current_user.thanks.where(receiver_id: receiver_id, group_id: group_id) # 該当group内でthankを受けたuserのthanksに絞り込み
+    thank_days = []
+    thanks_to_receiver.each do |thank|
+      thank_date = I18n.l thank.created_at
+      thank_days.push(thank_date)
+    end
+    today = I18n.l Date.current
+
+    if !thank_days.include?(today) && self.user_id != receiver_id
+      self.save
+    end
+  end
+
   # その日のデータか確認し、thank登録を元に戻す(削除する)
   def undo
     today = I18n.l Date.current


### PR DESCRIPTION
why
・同一日に重複して同じuser_id, receiver_id, group_idセットのデータが保存されてはいけない使用のため
・感謝登録者(user_id)と受け手(receiver_id)が同一にならないようにするため

what
Thankモデルにデータ保存時にフィルタリングがかかるようtell_thankメソッドを定義。それをコントローラで呼び出し。