### PR TITLE
トップページにて、フォームバリデーションエラーメッセージ重複表示のバグを修正 #87

### DIFF
--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -13,10 +13,12 @@
               <% else %>
 
                 <%= form_with model: @thank, local: true do |f| %>
-                  <%= render 'layouts/error_messages', model: f.object %>
-                  
+                  <% if @thank.receiver_id == user.id && @thank.group_id == group.id %>
+                    <%= render 'layouts/error_messages', model: f.object %>
+                  <% end %>
+
                   <div class="form-group">
-                    <%= f.label :content, "#{user.name} さんへ感謝"%>
+                    <%= f.label :content, "#{user.name} さんへ感謝" %>
                     <%= f.text_field :content, class: 'form-control' %>
                   </div>
                     <%= f.hidden_field :receiver_id, value: user.id %>


### PR DESCRIPTION
why
トップページにてフォーム送信時バリデーションエラーが発生すると、送信フォーム以外のフォームにもエラーメッセージが出力される事象が起きていた。現状のままではユーザが操作する際誤認を招いてしまう懸念があるため。

what
該当フォームのインスタンスに格納されている情報を元にビュー画面で条件分岐をした。