### PR TITLE
トップバリデーションエラー再描画時のフォームバグを修正 #89

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -1,8 +1,8 @@
 class ThanksController < ApplicationController
 
   def create
+    # @thankにはデータあり
     @thank = current_user.thanks.build(thank_params)
-
     if @thank.tell_thank(current_user, thank_params[:receiver_id], thank_params[:group_id])
       flash[:success] = '感謝を登録しました'
       redirect_to root_url

--- a/app/views/thanks/_thank_form.html.erb
+++ b/app/views/thanks/_thank_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: thank, local: true do |f| %>
+  <%= render 'layouts/error_messages', model: f.object %>
+
+  <div class="form-group">
+    <%= f.label :content, "#{user.name} さんへ感謝" %>
+    <%= f.text_field :content, class: 'form-control' %>
+  </div>
+  <%= f.hidden_field :receiver_id, value: user.id %>
+  <%= f.hidden_field :group_id, value: group.id %>
+  <%= f.submit '感謝', class: 'form-control btn btn-sm btn-info' %>
+<% end %>

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -11,21 +11,12 @@
               <% if thank_today(@thanks, user, group) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
                 <p><%= user.name %>さんに感謝を伝えました <%= link_to '元に戻す', thank_path(@today_thank), method: :delete, class: 'btn btn-secondary btn-md' %></p>
               <% else %>
-
-                <%= form_with model: @thank, local: true do |f| %>
-                  <% if @thank.receiver_id == user.id && @thank.group_id == group.id %>
-                    <%= render 'layouts/error_messages', model: f.object %>
-                  <% end %>
-
-                  <div class="form-group">
-                    <%= f.label :content, "#{user.name} さんへ感謝" %>
-                    <%= f.text_field :content, class: 'form-control' %>
-                  </div>
-                    <%= f.hidden_field :receiver_id, value: user.id %>
-                    <%= f.hidden_field :group_id, value: group.id %>
-                    <%= f.submit '感謝', class: 'form-control btn btn-sm btn-info' %>
+                <% if @thank.receiver_id == user.id && @thank.group_id == group.id %> <!-- 操作フォームには既存インスタンスをそのほかには新規インスタンスを渡す !-->
+                  <%= render 'thanks/thank_form', thank: @thank, user: user, group: group %>
+                <% else %>
+                  <% @thank = current_user.thanks.build %>
+                  <%= render 'thanks/thank_form', thank: @thank, user: user, group: group %>
                 <% end %>
-
               <% end %>
 
             <% end %>


### PR DESCRIPTION
why
フォーム文字数制限エラーの際、再描画すると操作フォーム以外のフォームにも入力内容が残った。操作性に支障があるため修正。

what
操作フォーム以外には新規インスタンスを渡すように、viewで条件分岐を活用し実装。