### PR TITLE
トップバリデーションエラー後に元に戻すを押した際のエラーを修正 #94

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -18,7 +18,7 @@ class ThanksController < ApplicationController
     thank = Thank.find_by(id: params[:id])
     thank.undo
     flash[:warning] = '習慣の状態を元に戻しました'
-    redirect_back(fallback_location: root_url)
+    redirect_to root_url
   end
 
   private


### PR DESCRIPTION
why
フォーム入力時、バリデーションエラーになり再描画された状態で「元に戻す」ボタンを押すとルーティングエラーが見られた。そのエラー修正のため。

what
thanksコントローラdestroyアクションを修正