### PR TITLE
ヘッダーにメイン機能リンクを追加 #93

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,6 +10,7 @@
             <% end %>
           <% end %>
           <li class="nav-item"><%= link_to '新規グループ作成', new_group_path, class: 'nav-link' %></li>
+          <li class="nav-item"><%= link_to '今日の感謝を登録', root_path, class: 'nav-link' %></li>
           <li class="nav-item dropdown">
             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><%= current_user.name %></a>
             <ul class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
why
メイン機能へのリンクがアプリ名のみだったためわかりにくかった。よりわかりやすくするため。

what
ヘッダーに改めてリンクを表示を追加