### PR TITLE
ヘッダーのグループ招待通知をドロップダウン表示に変更 条件分岐も修正 #59

### DIFF
--- a/app/helpers/group_users_helper.rb
+++ b/app/helpers/group_users_helper.rb
@@ -1,10 +1,10 @@
 module GroupUsersHelper
-  # userが承認していないgroup_usersを返す
+  # userが承認していないgroup_usersを取得
   def unpermit_group_users(user)
     @unpermit_group_users = user.group_users.where(permission: false)
   end
 
-  # group_userレコードのpermission:true or false を判定
+  # group_userインスタンスのpermission:true or false を判定
   def permitted_group_user?(user, group)
     group_user = user.group_users.find_by(group_id: group.id)
     group_user.permission # permissionの値を返す(true or false)

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,13 +4,18 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
       <ul class="navbar-nav">
         <% if logged_in? %>
-          <% if unpermit_group_users(current_user) %> <!-- 承認していないグループ招待があれば表示 !-->
-            <% unpermit_group_users(current_user).each do |unpermit_group_user| %>
-              <li class="nav-item"><%= link_to "#{unpermit_group_user.group.name}からの招待", invite_group_user_path(unpermit_group_user), class: 'nav-link' %></li>
-            <% end %>
-          <% end %>
           <li class="nav-item"><%= link_to '新規グループ作成', new_group_path, class: 'nav-link' %></li>
           <li class="nav-item"><%= link_to '今日の感謝を登録', root_path, class: 'nav-link' %></li>
+          <% unless unpermit_group_users(current_user) == []  %> <!-- 承認していないグループ招待があれば表示 !-->
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">グループから招待があります</a>
+              <ul class="dropdown-menu dropdown-menu-right">
+                <% unpermit_group_users(current_user).each do |unpermit_group_user| %>
+                  <li class="dropdown-item"><%= link_to "#{unpermit_group_user.group.name}からの招待", invite_group_user_path(unpermit_group_user) %></li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
           <li class="nav-item dropdown">
             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><%= current_user.name %></a>
             <ul class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
why
招待通知が複数件ある場合、ヘッダーリンクが見ずら差があった。見やすさと操作性を向上させるため。

what
ヘッダー表示をドロップダウン形式に変更