### PR TITLE
修正 #87 #89 バリデーションエラー時、最上部フォーム以外は正常に動作しない を解消 #104

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -1,8 +1,8 @@
 class ThanksController < ApplicationController
 
   def create
-    # @thankにはデータあり
     @thank = current_user.thanks.build(thank_params)
+
     if @thank.tell_thank(current_user, thank_params[:receiver_id], thank_params[:group_id])
       flash[:success] = '感謝を登録しました'
       redirect_to root_url

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -25,4 +25,14 @@ class Thank < ApplicationRecord
     thank_date = I18n.l self.created_at
     self.destroy if today == thank_date
   end
+
+  # インスタンスがuser_idのみの場合(toppage#indexから呼ばれている)にtrue
+  def clean_thank
+    self.receiver_id == nil && self.group_id == nil
+  end
+
+  # バリデーションエラー時インスタンスの操作フォームから生成されたものであればtrue
+  def operation_form_thank(user, group)
+    self.receiver_id == user.id && self.group_id == group.id
+  end
 end

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -11,11 +11,11 @@
               <% if thank_today(@thanks, user, group) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
                 <p><%= user.name %>さんに感謝を伝えました <%= link_to '元に戻す', thank_path(@today_thank), method: :delete, class: 'btn btn-secondary btn-md' %></p>
               <% else %>
-                <% if @thank.receiver_id == user.id && @thank.group_id == group.id %> <!-- 操作フォームには既存インスタンスをそのほかには新規インスタンスを渡す !-->
+                <% if @thank.clean_thank || @thank.operation_form_thank(user, group) %>
                   <%= render 'thanks/thank_form', thank: @thank, user: user, group: group %>
                 <% else %>
-                  <% @thank = current_user.thanks.build %>
-                  <%= render 'thanks/thank_form', thank: @thank, user: user, group: group %>
+                  <% @new_thank = current_user.thanks.build %>
+                  <%= render 'thanks/thank_form', thank: @new_thank, user: user, group: group %>
                 <% end %>
               <% end %>
 


### PR DESCRIPTION
why
フォーム入力時のバリデーションエラーのバグが見られたため。具体的には、最上部のフォーム操作時は正常に動作が見られたが、他のフォームで操作をしバリデーションエラーが出るとエラーメッセージが出力されなかった。

what
新規インスタンスに新しく変数名を付与し、条件分岐を活用した。Thankモデルにメソッドを定義、ビューで分岐を実装。