### PR TITLE
flashメッセージ、招待参加時確認メッセージを修正 #106

### DIFF
--- a/app/controllers/group_users_controller.rb
+++ b/app/controllers/group_users_controller.rb
@@ -3,7 +3,7 @@ class GroupUsersController < ApplicationController
 
   def create
     group_user = GroupUser.create(group_user_params)
-    flash[:success] = '招待保存成功'
+    flash[:success] = "#{group_user.user.name} さんを招待しました"
     redirect_to group_url(group_user.group_id)
   end
 
@@ -13,13 +13,13 @@ class GroupUsersController < ApplicationController
   def permit
     @group_user.permission = true
     @group_user.save
-    flash[:success] = "#{@group_user.group.name}に参加しました"
+    flash[:success] = "「#{@group_user.group.name}」に参加しました"
     redirect_to @group_user.group
   end
 
   def destroy
     @group_user.destroy
-    flash[:primary] = 'グループへの参加を辞退しました'
+    flash[:warning] = "「#{@group_user.group.name}」の招待を辞退しました"
     redirect_to root_url
   end
 

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -4,7 +4,7 @@ class ThanksController < ApplicationController
     @thank = current_user.thanks.build(thank_params)
 
     if @thank.tell_thank(current_user, thank_params[:receiver_id], thank_params[:group_id])
-      flash[:success] = '感謝を登録しました'
+      flash[:success] = "#{@thank.receiver.name} さんに感謝しました"
       redirect_to root_url
     else
       flash.now[:danger] = '感謝の登録に失敗しました'
@@ -17,7 +17,7 @@ class ThanksController < ApplicationController
   def destroy
     thank = Thank.find_by(id: params[:id])
     thank.undo
-    flash[:warning] = '習慣の状態を元に戻しました'
+    flash[:warning] = '状態を元に戻しました'
     redirect_to root_url
   end
 

--- a/app/views/group_users/invite.html.erb
+++ b/app/views/group_users/invite.html.erb
@@ -1,4 +1,4 @@
 <h3>"<%= @group_user.group.name %>" から招待されています</h3>
 
-<%= link_to '参加する', permit_group_user_path(@group_user), method: :put, data: { confirm: "#{@group_user.group.name}に参加しますか？" }, class: 'btn btn-primary btn-md' %>
+<%= link_to '参加する', permit_group_user_path(@group_user), method: :put, data: { confirm: "「#{@group_user.group.name}」に参加しますか？" }, class: 'btn btn-primary btn-md' %>
 <%= link_to '辞退する', group_user_path(@group_user), method: :delete, data: { confirm: "本当に「#{@group_user.group.name}」からの招待を辞退しますか？" }, class: 'btn btn-secondary btn-md' %>


### PR DESCRIPTION
why
flashメッセージ、確認メッセージがわかりずらく表示されていたため。

what
コントローラ、ビューのメッセージ文言を修正。