### PR TITLE
グループ詳細閲覧、編集、更新、ユーザ詳細画面遷移の操作を参加済みユーザに限定 #110

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :login_required
 
   include SessionsHelper
+  include GroupUsersHelper
 
   private
   def login_required

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  before_action :set_group, only: [:show, :edit, :update, :search_user]
+  before_action :correct_user, only: [:show, :edit, :update, :search_user]
 
   def new
     @group = Group.new
@@ -48,7 +48,12 @@ class GroupsController < ApplicationController
     params.require(:group).permit(:name)
   end
 
-  def set_group
+  # グループ参加済みユーザのみに限定
+  def correct_user
     @group = Group.find_by(id: params[:id])
+    unless permitted_group_user(current_user, @group)
+      flash[:danger] = 'エラー'
+      redirect_to root_url
+    end
   end
 end

--- a/app/helpers/group_users_helper.rb
+++ b/app/helpers/group_users_helper.rb
@@ -4,9 +4,9 @@ module GroupUsersHelper
     @unpermit_group_users = user.group_users.where(permission: false)
   end
 
-  # group_userインスタンスのpermission:true or false を判定
-  def permitted_group_user?(user, group)
+  # ユーザが参加済みのグループかどうか確認、返り値はtrue/false/nilの3通り
+  def permitted_group_user(user, group)
     group_user = user.group_users.find_by(group_id: group.id)
-    group_user.permission # permissionの値を返す(true or false)
+    group_user.permission unless group_user == nil
   end
 end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <% @users.each do |user| %>
-        <% if permitted_group_user?(user, @group) %>
+        <% if permitted_group_user(user, @group) %>
           <p><%= link_to user.name, user %></p>
         <% else %>
           <p><%= user.name %> さんを招待中</p>

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -1,12 +1,12 @@
 <% if logged_in? %>
   <h3>"<%= current_user.name %>"さん 1日1回大切な人に感謝を伝えましょう</h3>
   <% @groups.each do |group| %>
-    <% if permitted_group_user?(current_user, group) %> <!--参加済みグループのみを表示!-->
+    <% if permitted_group_user(current_user, group) %> <!--参加済みグループのみを表示!-->
       <div class="card mb-4">
         <h4 class="card-header text-center text-white bg-dark">グループ名: <%= link_to "#{group.name}", group, class: 'text-white' %></h4>
         <div class="card-body">
           <% group.users.each do |user| %>
-            <% if current_user != user && permitted_group_user?(user, group) %> <!-- ログインユーザでない 且つ 参加済みユーザのみを表示 !-->
+            <% if current_user != user && permitted_group_user(user, group) %> <!-- ログインユーザでない 且つ 参加済みユーザのみを表示 !-->
               
               <% if thank_today(@thanks, user, group) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
                 <p><%= user.name %>さんに感謝を伝えました <%= link_to '元に戻す', thank_path(@today_thank), method: :delete, class: 'btn btn-secondary btn-md' %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <% @groups.each do |group| %>
-      <% if permitted_group_user?(@user, group) %>
+      <% if permitted_group_user(@user, group) %>
         <p><%= link_to group.name, group %></p>
       <% else %>
         <p>「<%= group.name %>」 から招待されています</p>


### PR DESCRIPTION
why
未参加ユーザもグループについての操作が可能な仕様となっていたため。

what
参加済みユーザのみが操作可能なように、ヘルパーファイルのメソッドを修正。コントローラ内でも新たなメソッドを定義した。