### PR TITLE
ユーザ詳細閲覧、ユーザ情報編集、更新操作をログインユーザに限定 #112

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :login_required, only: [:new, :create]
-  before_action :set_user, only: [:show, :edit, :update]
+  before_action :correct_user, only: [:show, :edit, :update]
 
   def new
     @user = User.new
@@ -43,7 +43,11 @@ class UsersController < ApplicationController
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 
-  def set_user
+  def correct_user
     @user = User.find_by(id: params[:id])
+    unless @user == current_user
+      flash[:danger] = 'エラー'
+      redirect_to(root_url)
+    end
   end
 end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -7,9 +7,9 @@
 
       <% @users.each do |user| %>
         <% if permitted_group_user(user, @group) %>
-          <p><%= link_to user.name, user %></p>
+          <p><%= user.name %> さん</p>
         <% else %>
-          <p><%= user.name %> さんを招待中</p>
+          <p><%= user.name %> さん(招待中)</p>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
why
ログインユーザ以外のユーザもユーザ詳細閲覧、編集、更新の操作ができてしまう仕様にであった。好ましくない仕様のため修正。

what
usersコントローラを編集。他ユーザからのユーザ詳細画面へのリンクを消去。