### PR TITLE
感謝一覧表示のソート機能実装(ransack) #118

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'pry-byebug', group: :development
 gem 'kaminari'
 gem 'i18n_generators'
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -157,6 +159,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -227,6 +234,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.2)
+  ransack
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,8 @@ class GroupsController < ApplicationController
 
   def show
     @users = @group.users.order(id: :asc)
-    @thanks = @group.thanks.order(id: :desc)
+    @q = @group.thanks.ransack(params[:q])
+    @thanks = @q.result(distinct: true).order(id: :desc)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,8 @@ class UsersController < ApplicationController
 
   def show
     @groups = @user.groups.order(id: :asc)
-    @thanks = @user.thanks.order(id: :desc)
+    @q = @user.thanks.ransack(params[:q])
+    @thanks = @q.result(distinct: true).order(id: :desc)
   end
 
   def edit

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -23,7 +23,7 @@
           <th>感謝した人</th>
           <th>感謝された人</th>
           <th>感謝の内容</th>
-          <th>日付</th>
+          <th><%= sort_link  @q, :created_at, '日付(ソート)' %></th>
         </tr>
       </thead>
       <% @thanks.each do |thank| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,7 +24,7 @@
     <tr>
       <th><%= @user.name %> さんが感謝した人</th>
       <th>感謝の内容</th>
-      <th>日付</th>
+      <th><%= sort_link  @q, :created_at, '日付(ソート)' %></th>
     </tr>
   </thead>
   <% @thanks.each do |thank| %>


### PR DESCRIPTION
why
感謝一覧の日付ソート機能で感謝の検索ユーザ操作性を向上させるため。

what
ransack(gem)をインストール。ユーザ詳細、グループ詳細画面を日付を昇順降順ソートを変更可能な仕様に変更。