### PR TITLE
感謝検索機能、日付の以前検索がうまく動作せず 修正 #123

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -30,7 +30,7 @@
 
       <div class="form-group d-flex align-items-center row">
         <%= f.label :created_at, '期間', class: 'col-sm-2' %>
-        <%= f.date_field :created_at_lteq, class: 'form-control col-sm-4 ml-2 mr-1' %>以前
+        <%= f.date_field :created_at_lteq_end_of_day, class: 'form-control col-sm-4 ml-2 mr-1' %>以前
         <%= f.date_field :created_at_gteq, class: 'form-control col-sm-4 ml-2 mr-1' %>以降
       </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
 
       <div class="form-group d-flex align-items-center row">
         <%= f.label :created_at, '期間', class: 'col-sm-2' %>
-        <%= f.date_field :created_at_lteq, class: 'form-control col-sm-4 ml-2 mr-1' %>以前
+        <%= f.date_field :created_at_lteq_end_of_day, class: 'form-control col-sm-4 ml-2 mr-1' %>以前
         <%= f.date_field :created_at_gteq, class: 'form-control col-sm-4 ml-2 mr-1' %>以降
       </div>
 

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,6 @@
+Ransack.configure do |config|
+  config.add_predicate 'lteq_end_of_day',
+    arel_predicate: 'lteq',
+    formatter: proc {|v| v.end_of_day},
+    compounds: false
+end


### PR DESCRIPTION
why
日付の期間（以前）検索において、入力日付が含まれず検索されてしまっていたため。
what
ransack の設定ファイルを作成し、カスタムすることで機能修正を行った。