### PR TITLE
感謝一覧にkaminariを活用しページネーションを適用(bootstrapを適用、日本語化に対応) #121

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,7 +21,7 @@ class GroupsController < ApplicationController
   def show
     @users = @group.users.order(id: :asc)
     @q = @group.thanks.ransack(params[:q])
-    @thanks = @q.result(distinct: true).order(id: :desc)
+    @thanks = @q.result(distinct: true).order(id: :desc).page(params[:page]).per(15)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
   def show
     @groups = @user.groups.order(id: :asc)
     @q = @user.thanks.ransack(params[:q])
-    @thanks = @q.result(distinct: true).order(id: :desc)
+    @thanks = @q.result(distinct: true).order(id: :desc).page(params[:page]).per(15)
   end
 
   def edit

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination justify-content-center">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/thanks/_index.html.erb
+++ b/app/views/thanks/_index.html.erb
@@ -27,3 +27,4 @@
     </tbody>
   <% end %>
 </table>
+<%= paginate thanks %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,7 +58,7 @@ ja:
       short: "%m/%d"
       start_day: "%Y-%m-%d %H:%M:%S"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -221,3 +221,10 @@ ja:
       short: "%m/%d %H:%M"
       db: "%Y-%m-%d %H:%M:%S"
     pm: 午後
+  views:
+    pagination:
+      first: '最初'
+      last: '最後'
+      previous: '前'
+      next: '次'
+      truncate: '...'


### PR DESCRIPTION
why
ページネーション未対応で感謝件数増加の際に UIに欠けていたため

what
kaminari を活用しコントローラ、ビューを修正。合わせてkaminari を bootstrap、日本語化に対応させた。