### PR TITLE
ransackでの検索で意図しない動作を制限する設計を記述 #132

### DIFF
--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -4,6 +4,16 @@ class Thank < ApplicationRecord
   belongs_to :receiver, class_name: 'User'
   belongs_to :group
 
+  # ransackで検索可能なカラムを制限
+  def self.ransackable_attributes(auth_object = nil)
+    %w[content created_at]
+  end
+
+  # ransackで検索条件に意図しない関連を含めないように制限
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   # thank登録
   def tell_thank(current_user, receiver_id, group_id)
     thanks_to_receiver = current_user.thanks.where(receiver_id: receiver_id, group_id: group_id) # 該当group内でthankを受けたuserのthanksに絞り込み

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,14 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users, source: :group
   has_many :thanks #user.thanksでuserの送ったthanksを取得
   has_many :receiver_thanks, class_name: 'Thank', foreign_key: 'receiver_id' #user.receiver_thanksでuserの受け取ったthanksを取得
+
+  # ransackで検索可能なカラムを制限
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
+  # ransackで検索条件に意図しない関連を含めないように制限
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end


### PR DESCRIPTION
why
パラメーターに直接送信すれば意図しないカラムの検索が行えてしまう仕様になっていた。その状態ではセキュリティの脆弱性に繋がるため。

what
意図しないパラメーターが送信された際でも、検索を行わないような制限をThank, Userモデルに設定。