### PR TITLE
グループ詳細、ユーザ詳細ページ画面幅変更時のスタイルの重なりを修正 #57

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,12 +1,11 @@
 <h1 class="text-center">"<%= @group.name %>"みんなの感謝</h1>
 
 <div class="row mt-4">
-  <div class="col-sm-4">
-    <div class="card" style="width: 24rem;">
+  <aside class="col-sm-4">
+    <div class="card">
       <div class="card-body">
         <h4 class="card-title text-center">"<%= @group.name %>"</h4>
       </div>
-
       <% @users.each do |user| %>
         <% if permitted_group_user(user, @group) %>
           <p><%= user.name %> さん</p>
@@ -15,12 +14,11 @@
         <% end %>
       <% end %>
     </div>
-  
     <%= link_to 'グループにユーザを追加', search_user_group_path(@group) %><br>
     <%= link_to 'グループ名変更', edit_group_path(@group) %>
-  </div>
+  </aside>
 
-  <div class="col-sm-7 offset-sm-1">
+  <div class="col-sm-8">
     <%= render 'thanks/search_form', q: @q, url: group_path(@group) %>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,11 @@
 <h1 class="text-center"><%= @user.name %>さんのページ</h1>
 
 <div class="row mt-4">
-
-  <div class="col-sm-4">
-    <div class="card" style="width: 24rem;">
+  <aside class="col-sm-4">
+    <div class="card">
       <div class="card-body">
         <h4 class="card-title text-center"><%= @user.name %> さんのグループ</h4>
       </div>
-
       <% @groups.each do |group| %>
         <% if permitted_group_user(@user, group) %>
           <p><%= link_to group.name, group %></p>
@@ -15,13 +13,11 @@
           <p>「<%= group.name %>」 から招待されています</p>
         <% end %>
       <% end %>
-
     </div>
-    <!-- ログインユーザをの場合のみ表示 !-->
     <%= link_to 'アカウント情報編集', edit_user_path(current_user) %>
-  </div>
+  </aside>
 
-  <div class="col-sm-7 offset-sm-1">
+  <div class="col-sm-8">
     <%= render 'thanks/search_form', q: @q, url: user_path(@user) %>
   </div>
 


### PR DESCRIPTION
why
画面幅を狭めるとスタイルが崩れたため。具体的には、カードと検索フォームの重なりが見られた。

what
グループ詳細、ユーザ詳細を修正。カードの幅設定を無効にすることで解消。