### PR TITLE
フォーム送信確認ダイアログが２重表示されることを解消 #138

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,3 @@
 //= require turbolinks
 //= require_tree .
 //= require jquery
-//= require jquery_ujs


### PR DESCRIPTION
why
ユーザグループ招待への確認ダイアログ表示が2回表示されてしまい、2回クリックしないと送信されなかったため。

what
application.js にてjquery 読み込みの不要な記述がされていたため削除。
