### PR TITLE
感謝一覧データ取得の順をidからcreated_atに変更 #142

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,7 +21,7 @@ class GroupsController < ApplicationController
   def show
     @users = @group.users.order(id: :asc)
     @q = @group.thanks.ransack(params[:q]) # search_form_for用
-    @thanks = @q.result(distinct: true).order(id: :desc).page(params[:page]).per(15)
+    @thanks = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(15)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
   def show
     @groups = @user.groups.order(id: :asc)
     @q = @user.thanks.ransack(params[:q])
-    @thanks = @q.result(distinct: true).order(id: :desc).page(params[:page]).per(15)
+    @thanks = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(15)
   end
 
   def edit


### PR DESCRIPTION
why
感謝一覧表示で日付順に表示したいが、現状id順でデータを取得していた。id順でも日付順と変わらず動作が期待できるが、より意図せぬ挙動が起きにくくするため。

what
コントローラでデータ取得の順番を修正。