### PR TITLE
issue #146 を修正 binding.pry の記述を削除 #148

### DIFF
--- a/app/helpers/thanks_helper.rb
+++ b/app/helpers/thanks_helper.rb
@@ -7,7 +7,6 @@ module ThanksHelper
     thank_days = thanks_to_receiver.map { |thank| thank_date = I18n.l thank.created_at }
 
     today = I18n.l Date.current
-    binding.pry
     if thank_days.include?(today)
       @today_thank = thanks_to_receiver.last
     else


### PR DESCRIPTION
why
デバックツールの binding.pry の記述を残したままコミット＋マージをしてしまったため。

what
 binding.pry の記述を削除。