### PR TITLE
toppagesコントローラ、indexアクションの不要な記述を削除 #150

### DIFF
--- a/app/controllers/toppages_controller.rb
+++ b/app/controllers/toppages_controller.rb
@@ -4,8 +4,8 @@ class ToppagesController < ApplicationController
   def index
     if logged_in?
       @groups = current_user.groups.order(id: :desc).page(params[:page]).per(5)
+      @thanks = current_user.thanks
       @thank = current_user.thanks.build # form_with 用
-      @thanks = current_user.thanks.where.not(created_at: nil) # 上記@thankを除外して検索
     end
   end
 end


### PR DESCRIPTION
why
コードの記述工夫により、不要な記述を削除可能なため

what
form_with用インスタンスを除外してデータを取得するために、コードの記述順を変更して不要な取得条件を削除した。