### PR TITLE
グループ詳細ページのレイアウトを修正。検索フォームとグループユーザをライトサイドバーへ。 #160

### DIFF
--- a/app/assets/stylesheets/_groups_show.scss
+++ b/app/assets/stylesheets/_groups_show.scss
@@ -1,0 +1,19 @@
+
+
+.groups-container {
+  display: flex;
+
+  &__main-content {
+    max-width: 850px;
+    flex: 4;
+    margin: 50px auto;
+  }
+
+  &__right-content {
+    flex: 1;
+    max-width: 250px;
+    margin-right: 8px;
+    padding-top: 50px;
+    border: solid 1px #e4e1e1;
+  }
+}

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -2,12 +2,12 @@ $baseBlue: #0c8dd3;
 
 .sidebar {
   width: 15%;
-  min-width: 250px;
+  min-width: 150px;
   max-height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: $baseBlue;
-  font-size: 20px;
+  font-size: 18px;
   text-align: center;
 
   a {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,29 +15,19 @@
  */
 
 
- .header-title {
-  display: none;
- }
-
  .layout {
    display: flex;
    min-height: 100vh;
 
-
    .main {
      flex: 1;
-     max-width: 900px;
-     margin: 0 auto;
+    //  max-width: 900px;
+    //  margin: 0 auto;
    }
   }
 
   @media screen and (max-width: 900px) {
 
-    .header-title {
-      display: block;
-      text-align: center;
-      background-color: #4d648d;
-    }
     .main {
       padding-top: 50px;
     }

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,7 +1,12 @@
-<h1 class="text-center">"<%= @group.name %>"みんなの感謝</h1>
+<div class="groups-container">
 
-<div class="row mt-4">
-  <aside class="col-sm-4">
+  <div class="groups-container__main-content">
+    <%= render 'thanks/index', user: current_user, thanks: @thanks, q: @q %>
+  </div>
+
+  <div class="groups-container__right-content">
+    <%= render 'thanks/search_form', q: @q, url: group_path(@group) %>
+
     <div class="card">
       <div class="card-body">
         <h4 class="card-title text-center">"<%= @group.name %>"</h4>
@@ -16,11 +21,6 @@
     </div>
     <%= link_to 'グループにユーザを追加', search_user_group_path(@group) %><br>
     <%= link_to 'グループ名変更', edit_group_path(@group) %>
-  </aside>
-
-  <div class="col-sm-8">
-    <%= render 'thanks/search_form', q: @q, url: group_path(@group) %>
   </div>
 
 </div>
-<%= render 'thanks/index', user: current_user, thanks: @thanks, q: @q %>


### PR DESCRIPTION
why
UI/UXの向上を目指すため。

what
グループ詳細ページのレイアウトを修正。