### PR TITLE
ユーザ詳細ページレイアウトを修正。検索フォームとグループ名表示を右サイドバーへ移動。 #161

### DIFF
--- a/app/assets/stylesheets/_users_show.scss
+++ b/app/assets/stylesheets/_users_show.scss
@@ -1,5 +1,5 @@
 
-.groups-container {
+.users-container {
   display: flex;
   min-height: 100vh;
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,11 @@
-<h1 class="text-center"><%= @user.name %>さんのページ</h1>
+<div class="users-container">
 
-<div class="row mt-4">
-  <aside class="col-sm-4">
+  <div class="users-container__main-content">
+    <%= render 'thanks/index', user: @user, thanks: @thanks, q: @q %>
+  </div>
+
+  <div class="users-container__right-content">
+    <%= render 'thanks/search_form', q: @q, url: user_path(@user) %>
     <div class="card">
       <div class="card-body">
         <h4 class="card-title text-center"><%= @user.name %> さんのグループ</h4>
@@ -15,11 +19,6 @@
       <% end %>
     </div>
     <%= link_to 'アカウント情報編集', edit_user_path(current_user) %>
-  </aside>
-
-  <div class="col-sm-8">
-    <%= render 'thanks/search_form', q: @q, url: user_path(@user) %>
   </div>
 
 </div>
-<%= render 'thanks/index', user: @user, thanks: @thanks, q: @q %>


### PR DESCRIPTION
why
UI/UXの向上を目指すため。

what
ユーザ詳細ページのレイアウトを修正。