### PR TITLE
感謝検索ボタン適用範囲が狭いため、広げる #201

### DIFF
--- a/app/assets/stylesheets/_thank-search-container.scss
+++ b/app/assets/stylesheets/_thank-search-container.scss
@@ -60,18 +60,12 @@
     }
   }
 
-  &__submit {
-    display: flex;
-    justify-content: center;
+  &__submit-btn {
     width: 100%;
-    font-size: 28px;
-    padding: 0;
+    color: $c-deep-blue;
     border: 1px solid $c-deep-blue;
     border-radius: 6px;
-
-    & btn {
-      color: $c-deep-blue;
-    }
+    margin-bottom: 5px;
   }
 
   &__undo-link a {

--- a/app/views/thanks/_search_form.html.erb
+++ b/app/views/thanks/_search_form.html.erb
@@ -1,26 +1,17 @@
 <div class="thank-search-container">
-
   <div class="thank-search-container__head">日付で絞り込む</div>
-
   <%= search_form_for q, url: url, class: "thank-search-form-group" do |f| %>
-
     <div class="thank-search-form-group__upper">
       <%= f.date_field :created_at_lteq_end_of_day, class: 'form-control thank-search-form-group__upper--input' %>
       <div class="thank-search-form-group__upper--label">以前</div>
     </div>
-
     <div class="thank-search-form-group__lower">
       <%= f.date_field :created_at_gteq, class: 'form-control thank-search-form-group__lower--input' %>
       <div class="thank-search-form-group__lower--label">以降</div>
     </div>
-
-    <div class="thank-search-form-group__submit">
-      <%= button_tag sanitize('<i class="fas fa-search"></i>検索'), type: "submit", class: "btn" %>
-    </div>
-
+    <%= button_tag sanitize('<i class="fas fa-search"></i>検索'), type: "submit", class: "btn thank-search-form-group__submit-btn" %>
     <div class="thank-search-form-group__undo-link">
       <%= link_to '全件表示に戻す', url %>
     </div>
   <% end %>
-
 </div>


### PR DESCRIPTION
why
感謝ボタンの反応する範囲が狭く操作性に欠けていたため。

what
ボタンの反応範囲を幅一杯に適用するようにscssを修正。