### PR TITLE
ユーザ詳細、グループ詳細ページ右サイドバー表示非表示切替。 #203

### DIFF
--- a/app/assets/stylesheets/_details-page-header.scss
+++ b/app/assets/stylesheets/_details-page-header.scss
@@ -4,7 +4,7 @@
   color: $c-deep-gray;
   font-size: 35px;
   text-align: center;
-  
+
   &__face-icon {
     font-size: 50px;
     color: $c-blue;
@@ -18,8 +18,9 @@
 
 .date-switching {
   text-align: end;
-  margin-bottom: 15px;
+  width: 80%;
+  margin: 0 auto 15px;
 }
 .sort_link {
-  color: black;
+  color: $c-deep-blue;
 }

--- a/app/assets/stylesheets/_groups-container.scss
+++ b/app/assets/stylesheets/_groups-container.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
 
   &__main-content {
-    flex: 4;
+    flex: 7;
     padding: 25px 0;
     max-width: 850px;
     overflow: auto;
@@ -12,7 +12,14 @@
   }
 
   &__right-content {
-    flex: 1;
+    flex: 3;
     max-width: 350px;
+  }
+}
+
+@media screen and (max-width: 900px) {
+
+  .groups-container__right-content {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/_sub_header.scss
+++ b/app/assets/stylesheets/_sub_header.scss
@@ -1,0 +1,14 @@
+@import "setup";
+
+.sub-header {
+  display: none;
+}
+
+@media screen and (max-width: 900px) {
+
+  .sub-header {
+    display: flex;
+    min-height: 195px;
+    background-color: $c-light-blue;
+  }
+}

--- a/app/assets/stylesheets/_thank-search-container.scss
+++ b/app/assets/stylesheets/_thank-search-container.scss
@@ -35,7 +35,6 @@
       flex: 1;
       display: flex;
       align-items: center;
-      min-width: 45px;
       padding-left: 5px;
       font-size: 17px;
     }
@@ -54,7 +53,6 @@
       flex: 1;
       display: flex;
       align-items: center;
-      min-width: 45px;
       padding-left: 5px;
       font-size: 17px;
     }
@@ -72,5 +70,72 @@
     display: flex;
     justify-content: flex-end;
     color: $c-deep-blue;
+  }
+}
+
+// サブヘッダー表示の際適用
+@media screen and (max-width: 900px) {
+
+  .thank-search-container {
+    margin: 2px auto;
+    width: 75%;
+    border: none;
+    color: #fff;
+
+    &__head {
+      max-width: 80%;
+      margin: 0 auto;
+      justify-content: flex-start;
+      min-height: 20px;
+      background-color: transparent;
+      font-size: 18px;
+      margin-bottom: 3px;
+    }
+  }
+
+  .thank-search-form-group {
+    width: 80%;
+    min-width: 300px;
+    margin: 0 auto;
+
+    &__upper {
+      margin-bottom: 6px;
+
+      &--input {
+        flex: 7;
+      }
+
+      &--label {
+        flex: 1;
+        font-size: 15px;
+      }
+    }
+
+    &__lower {
+      margin-bottom: 6px;
+
+      &--input {
+        flex: 7;
+      }
+
+      &--label {
+        flex: 1;
+        font-size: 15px;
+      }
+    }
+
+    &__submit-btn {
+      width: 87.5%;
+      color: #fff;
+      background-color: $c-deep-blue;
+      border-radius: 6px;
+      margin-bottom: 5px;
+    }
+
+    &__undo-link a {
+      display: flex;
+      justify-content: flex-start;
+      color: $c-deep-blue;
+    }
   }
 }

--- a/app/assets/stylesheets/_users-container.scss
+++ b/app/assets/stylesheets/_users-container.scss
@@ -1,18 +1,20 @@
+@import "groups-container";
+
 .users-container {
-  display: flex;
-  justify-content: center;
-  min-height: 100vh;
+  @extend .groups-container;
 
   &__main-content {
-    flex: 4;
-    padding: 25px 0;
-    max-width: 850px;
-    overflow: auto;
-    height: 100vh;
+    @extend .groups-container__main-content;
   }
 
   &__right-content {
-    flex: 1;
-    max-width: 350px;
+    @extend .groups-container__right-content;
+  }
+}
+
+@media screen and (max-width: 900px) {
+
+  .users-container__right-content {
+    display: none;
   }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
       flash[:success] = 'ユーザ情報を更新しました'
       redirect_to @user
     else
-      flash.now[:danger] = 'ユーザ情報の更新に失敗しました'
+      flash.n ow[:danger] = 'ユーザ情報の更新に失敗しました'
       render :edit
     end
   end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,12 +1,10 @@
+<%= render 'layouts/sub_header', q: @q, url: group_path(@group) %> <!-- 画面幅縮小時のみ表示 -->
 <div class="groups-container">
-
   <div class="groups-container__main-content">
     <%= render 'thanks/index', user: current_user, thanks: @thanks, q: @q, group: @group %>
   </div>
-
   <div class="groups-container__right-content">
     <%= render 'thanks/search_form', q: @q, url: group_path(@group) %>
-
     <div class="join-user-container">
       <div class="join-user-container__head">
         <%= @group.name %>
@@ -30,8 +28,6 @@
           <%= link_to 'グループ名を変更', edit_group_path(@group) %>
         </div>
       </div>
-
     </div>
   </div>
-
 </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,6 @@
 <div class="header">
   <label for="menu-icon" class="header__open-icon"><i class="fas fa-bars"></i></label>
   <%= link_to 'ThanksHabit', root_path, class: "header__title" %>
-
   <ul class="header__nav">
     <% if logged_in? %>
       <li class="header__nav--link-list"><%= link_to '新規グループ作成', new_group_path %></li>
@@ -40,7 +39,7 @@
 
 <label for="menu-icon" class="back"></label>
 
-<aside class="sidebar">
+<aside class="sidebar"> <!-- 画面幅縮小時ハンバーガーメニューで表示 -->
   <label for="menu-icon" class="sidebar__close-icon"><i class="fas fa-times fa-2x"></i></label>
 
   <% if logged_in? %> <!-- ログイン時サイドバー !-->
@@ -48,18 +47,50 @@
       <ul class="sidebar__nav--link-list">
         <li><%= link_to  '感謝を送る', root_path %></li>
         <li><%= link_to 'グループを作る', new_group_path %></li>
-
         <% unless unpermit_group_users(current_user) == []  %> <!-- 承認していないグループ招待があれば表示 !-->
           <li class="nav-item dropdown"> <!-- ドロップダウンにはBootstrapを採用 -->
             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">招待があります</a>
-            <ul class="dropdown-menu dropdown-menu-right">
+            <ul class="dropdown-menu dropdown-menu-left">
               <% unpermit_group_users(current_user).each do |unpermit_group_user| %>
-                <li class="dropdown-item"><%= link_to "「#{unpermit_group_user.group.name}」招待", check_group_user_path(unpermit_group_user), class: "dropdown-item__link" %></li>
+                <li class="dropdown-item">
+                  <%= link_to "「#{unpermit_group_user.group.name}」招待", check_group_user_path(unpermit_group_user), class: "dropdown-item__link" %>
+                </li>
               <% end %>
             </ul>
           </li>
         <% end %>
-
+        <% if @user && @user.id != nil && current_page?(user_path(@user)) %> <!-- ユーザ詳細画面にいるときのみ表示 -->
+          <li class="nav-item dropdown"> <!-- ドロップダウンにはBootstrapを採用 -->
+            <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">参加グループ</a>
+            <ul class="dropdown-menu dropdown-menu-left">
+              <% @groups.each do |group| %>
+                <% if permitted_group_user(@user, group) %>
+                  <li class="dropdown-item">
+                    <%= link_to group.name, group %>
+                  </li>
+                <% end %>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+        <% if @group && @group.id != nil && current_page?(group_path(@group)) %> <!-- グループ詳細画面にいるときのみ表示 -->
+          <li class="nav-item dropdown"> <!-- ドロップダウンにはBootstrapを採用 -->
+            <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">グループユーザ</a>
+            <ul class="dropdown-menu dropdown-menu-left">
+              <% @users.each do |user| %>
+                <li class="dropdown-item">
+                  <% if permitted_group_user(user, @group) %>
+                    <%= user.name %> さん
+                  <% else %>
+                    <%= user.name %> さん(招待中)
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          </li>
+          <li><%= link_to 'ユーザを招待', search_user_group_path(@group) %></li>
+          <li><%= link_to 'グループ名を変更', edit_group_path(@group) %></li>
+        <% end %>
       </ul>
     </div>
     <div class="sidebar__footer">
@@ -70,7 +101,6 @@
         <li class="sidebar__footer--link-list"><%= link_to 'ログアウト', logout_path, method: :delete %></li>
       </ul>
     </div>
-
   <% else %> <!-- 未ログイン時 サイドバー -->
     <div class="sidebar__nav">
       <% if current_page?(root_path) %>

--- a/app/views/layouts/_sub_header.html.erb
+++ b/app/views/layouts/_sub_header.html.erb
@@ -1,0 +1,3 @@
+<div class="sub-header">
+  <%= render 'thanks/search_form', q: q, url: url %>
+</div>

--- a/app/views/thanks/_search_form.html.erb
+++ b/app/views/thanks/_search_form.html.erb
@@ -1,5 +1,7 @@
 <div class="thank-search-container">
-  <div class="thank-search-container__head">日付で絞り込む</div>
+  <div class="thank-search-container__head">
+    日付で絞り込む
+  </div>
   <%= search_form_for q, url: url, class: "thank-search-form-group" do |f| %>
     <div class="thank-search-form-group__upper">
       <%= f.date_field :created_at_lteq_end_of_day, class: 'form-control thank-search-form-group__upper--input' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,10 @@
+<%= render 'layouts/sub_header', q: @q, url: user_path(@user) %> <!-- 画面幅縮小時のみ表示 -->
 <div class="users-container">
-
   <div class="users-container__main-content">
     <%= render 'thanks/index', user: @user, thanks: @thanks, q: @q %>
   </div>
-
   <div class="users-container__right-content">
     <%= render 'thanks/search_form', q: @q, url: user_path(@user) %>
-
     <div class="join-group-container">
       <div class="join-group-container__head">
         参加グループ


### PR DESCRIPTION
why
ユーザ詳細、グループ詳細ページが画面幅縮小時に対応しておらず、デザイン性、操作性に欠けていたため。

what
画面幅縮小時に右サイドバーを非表示にし、非表示にした要素をハンバーガーメニュークリック時表示の左サイドバーとヘッダーに表示するように変更した。