### PR TITLE
usersコントローラupdateアクションの記述に不備が見られたため修正。 #207

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
       flash[:success] = 'ユーザ情報を更新しました'
       redirect_to @user
     else
-      flash.n ow[:danger] = 'ユーザ情報の更新に失敗しました'
+      flash.now[:danger] = 'ユーザ情報の更新に失敗しました'
       render :edit
     end
   end


### PR DESCRIPTION
why
ユーザ情報更新時失敗時のコードに不備が見られたため。

what
updateアクション内を修正。