### PR TITLE
参加グループがない場合のトップページにメッセージを追加。 #209

### DIFF
--- a/app/assets/stylesheets/_group-container.scss
+++ b/app/assets/stylesheets/_group-container.scss
@@ -11,6 +11,12 @@
   }
 }
 
+.no-group-message {
+  text-align: center;
+  margin-top: 50px;
+  font-size: 18px;
+}
+
 .group-container {
   margin: 0 auto 30px;
   width: 96%;

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -1,5 +1,11 @@
 <% if logged_in? %>
   <h1 class="header-message">１日１回、感謝を言葉に<i class="far fa-envelope"></i></h1>
+  <% if @groups == [] %>
+    <p class="no-group-message">
+      参加グループがありません<br>
+      グループを作成してユーザを招待しよう
+    </p>
+  <% end %>
   <% @groups.each do |group| %>
     <% if permitted_group_user(current_user, group) %> <!--参加済みグループのみを表示!-->
       <div class="group-container">


### PR DESCRIPTION
why
グループに所属していない際の案内メッセージなどがなく、ユーザを不安にさせてしまうことが危惧されたため。

what
トップページにグループに所属していない場合の条件分岐を用意し、メッセージを表示。