### PR TITLE
画面幅縮小時サイドバー、背景画面からスクロール出来ないよう固定 #213

### DIFF
--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -123,11 +123,12 @@ input[type="checkbox"] {
   }
 
   input[type="checkbox"]:checked ~ .sidebar {
+    position: fixed;
     left: 0;
   }
 
   input[type="checkbox"]:checked ~ .back {
-    position: absolute;
+    position: fixed;
     z-index: 1;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
why
サイドバー表示の際不要な要素までもスクロール出来てしまうようになっていたため。

what
サイドバー、背景画面にposition: fixed; を付与し、画面を固定。