### PR TITLE
テーブルカラムの制限文字数を変更。フォームおよび、メニューリンク文言修正。 #215

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 50 }
+  validates :name, presence: true, length: { maximum: 20 }
 
   has_many :group_users
   has_many :users, through: :group_users, source: :user

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -1,5 +1,5 @@
 class Thank < ApplicationRecord
-  validates :content, presence: true, length: { maximum: 150 }
+  validates :content, presence: true, length: { maximum: 50 }
   belongs_to :user
   belongs_to :receiver, class_name: 'User'
   belongs_to :group

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   before_save { self.email.downcase! }
 
-  validates :name, presence: true, length: { maximum: 30 }, uniqueness: true
+  validates :name, presence: true, length: { maximum: 15 }, uniqueness: true
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
                     uniqueness: { case_sensitive: false }

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render 'layouts/error_messages', model: f.object %>
 
   <div class="group-form__group">
-    <%= f.label :name, 'グループ名', class: "group-form__group--label" %>
+    <%= f.label :name, 'グループ名（20文字以内）', class: "group-form__group--label" %>
     <%= f.text_field :name, class: 'form-control' %>
   </div>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,8 +5,8 @@
   <%= link_to 'ThanksHabit', root_path, class: "header__title" %>
   <ul class="header__nav">
     <% if logged_in? %>
-      <li class="header__nav--link-list"><%= link_to '新規グループ作成', new_group_path %></li>
-      <li class="header__nav--link-list"><%= link_to '今日の感謝を登録', root_path %></li>
+      <li class="header__nav--link-list"><%= link_to 'グループを作る', new_group_path %></li>
+      <li class="header__nav--link-list"><%= link_to '感謝を送る', root_path %></li>
       <% unless unpermit_group_users(current_user) == []  %> <!-- 承認していないグループ招待があれば表示 !-->
         <li class="header__nav--link-list nav-item dropdown">
           <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">招待があります</a>
@@ -22,7 +22,7 @@
         <ul class="dropdown-menu dropdown-menu-right">
           <li class="dropdown-item"><%= link_to 'マイページ', current_user, class: "dropdown-item__link" %></li>
           <li class="dropdown-divider"></li>
-          <li class="dropdown-item"><%= link_to 'アカウント情報編集', edit_user_path(current_user), class: "dropdown-item__link" %></li>
+          <li class="dropdown-item"><%= link_to 'ユーザ情報編集', edit_user_path(current_user), class: "dropdown-item__link" %></li>
           <li class="dropdown-divider"></li>
           <li class="dropdown-item"><%= link_to 'ログアウト', logout_path, method: :delete, class: "dropdown-item__link" %></li>
         </ul>
@@ -97,7 +97,7 @@
       <div class="sidebar__footer--current-user"><%= current_user.name %></div>
       <ul class="sidebar__footer--link">
         <li class="sidebar__footer--link-list"><%= link_to 'マイページ', current_user %></li>
-        <li class="sidebar__footer--link-list"><%= link_to 'アカウント情報編集', edit_user_path(current_user), class: "dropdown-item__link" %></li>
+        <li class="sidebar__footer--link-list"><%= link_to 'ユーザ情報編集', edit_user_path(current_user), class: "dropdown-item__link" %></li>
         <li class="sidebar__footer--link-list"><%= link_to 'ログアウト', logout_path, method: :delete %></li>
       </ul>
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render 'layouts/error_messages', model: f.object %>
 
   <div class="account-form__group">
-    <%= f.label :name, 'ユーザ名', class: "account-form__group--label" %>
+    <%= f.label :name, 'ユーザ名（15文字以内）', class: "account-form__group--label" %>
     <%= f.text_field :name, class: 'form-control' %>
   </div>
 


### PR DESCRIPTION
why
テーブルカラムについては文字数が多すぎる設定になっていたため。フォーム文言修正は文字数制限に伴いユーザ入力時にわかりやすくするため。
ヘッダー、サイドバーメニューもよりユーザにわかりやすくするため。

what
Thank, User, Groupモデルバリデーション設定を変更。フォームラベル文言を修正。
メニューリンク表示文言を修正。