### PR TITLE
マイページ表示感謝を自分が送った感謝から自分が受け取った投稿に変更 #217

### DIFF
--- a/app/assets/stylesheets/_thank_card.scss
+++ b/app/assets/stylesheets/_thank_card.scss
@@ -1,7 +1,7 @@
 @import "setup";
 
 .thank-card {
-  margin: 0 auto 15px;
+  margin: 0 auto 20px;
   width: 80%;
   min-width: 200px;
   min-height: 150px;
@@ -10,6 +10,11 @@
   color: $c-deep-gray;
   background-color: #fcebeb;
 
+  &__group-name {
+    padding: 3px 0 3px 18px;
+    color: $c-gray;
+  }
+
   &__upper-info {
     display: flex;
     height: 55%;
@@ -17,7 +22,7 @@
     margin: 0 auto;
     text-align: center;
     align-items: center;
-    border-bottom: 1px solid rgb(207, 207, 207);
+    border-bottom: 1px solid #cfcfcf;
 
     &--send-user {
       flex: 2;
@@ -37,7 +42,7 @@
       color: $c-pink;
       font-size: 38px;
     }
-    
+
     &--reciever {
       flex: 2;
 
@@ -65,10 +70,9 @@
     }
 
     &--date {
-      flex: 1;
-      color: #918f8f;
+      color: $c-gray;
       text-align: end;
-      padding: 0 18px 0 10px;
+      padding-right: 18px;
     }
   }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,8 +21,8 @@ class UsersController < ApplicationController
 
   def show
     @groups = @user.groups.order(id: :asc)
-    @q = @user.thanks.ransack(params[:q])
-    @thanks = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(15)
+    @q = Thank.ransack(params[:q])
+    @thanks = @q.result(distinct: true).where(receiver_id: current_user.id).order(created_at: :desc).page(params[:page]).per(15)
   end
 
   def edit

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -59,7 +59,7 @@
             </ul>
           </li>
         <% end %>
-        <% if @user && @user.id != nil && current_page?(user_path(@user)) %> <!-- ユーザ詳細画面にいるときのみ表示 -->
+        <% if current_page?(user_path(current_user)) %> <!-- ユーザ詳細画面にいるときのみ表示 -->
           <li class="nav-item dropdown"> <!-- ドロップダウンにはBootstrapを採用 -->
             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">参加グループ</a>
             <ul class="dropdown-menu dropdown-menu-left">

--- a/app/views/thanks/_index.html.erb
+++ b/app/views/thanks/_index.html.erb
@@ -1,7 +1,7 @@
 <div class="details-page-header">
   <div class="details-page-header__title">
     <% if current_page?(user_path(user)) %>
-      <%= user.name %> さん
+      <%= user.name %> さんが貰った
     <% else %>
       <%= group.name %>
     <% end %>
@@ -15,6 +15,11 @@
 </div>
   <% thanks.each do |thank| %>
     <div class="thank-card">
+      <% if current_page?(user_path(current_user)) %> <!-- ユーザ詳細画面の場合はグループ名を表示 -->
+        <div class="thank-card__group-name">
+          <i class="fas fa-user-friends"></i> <%= thank.group.name %>
+        </div>
+      <% end %>
       <div class="thank-card__upper-info">
         <div class="thank-card__upper-info--send-user">
           <div class="thank-card__upper-info--send-user--icon"><i class="far fa-laugh-wink"></i></div>


### PR DESCRIPTION
why
ユーザが感謝される喜びを実感しやすくするため。

what
マイページ感謝一覧表示内容をログインユーザが投稿した感謝から、受け取った感謝に変更。合わせてグループ名表示も行った。