### PR TITLE
ヘッダーメニューレイアウト、各ページメッセージカラーを修正。 #221

### DIFF
--- a/app/assets/stylesheets/_check_invitation.scss
+++ b/app/assets/stylesheets/_check_invitation.scss
@@ -3,6 +3,7 @@
 
 .check-invitation-header {
   @extend .account-header;
+  color: $c-deep-gray;
 }
 
 .check-invitation-container {

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -65,10 +65,11 @@
     font-size: 20px;
 
     &--link-list {
-      margin-left: 10px;
+      margin-left: 20px;
 
       a {
         color: #fff;
+        padding: 0;
       }
     }
   }

--- a/app/assets/stylesheets/_search-user.scss
+++ b/app/assets/stylesheets/_search-user.scss
@@ -4,6 +4,7 @@
   margin: 25px auto;
   width: 96%;
   max-width: 800px;
+  color: $c-deep-gray;
 
   &__header {
     font-size: 28px;
@@ -37,7 +38,7 @@
 
   &__status {
     font-size: 20px;
-    
+
     &--before,
     &--failed {
       text-align: center;

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,8 +5,8 @@
   <%= link_to 'ThanksHabit', root_path, class: "header__title" %>
   <ul class="header__nav">
     <% if logged_in? %>
-      <li class="header__nav--link-list"><%= link_to 'グループを作る', new_group_path %></li>
       <li class="header__nav--link-list"><%= link_to '感謝を送る', root_path %></li>
+      <li class="header__nav--link-list"><%= link_to 'グループを作る', new_group_path %></li>
       <% unless unpermit_group_users(current_user) == []  %> <!-- 承認していないグループ招待があれば表示 !-->
         <li class="header__nav--link-list nav-item dropdown">
           <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">招待があります</a>


### PR DESCRIPTION
why
より使いやすいデザインにするため。

what
ヘッダーメニューリンクの間隔をより大きくとり、見やすいように設置。各ページのメッセージを黒からグレーに変更した。