### PR TITLE
Thank登録、削除の処理を効率化 #155

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -4,7 +4,7 @@ class ThanksController < ApplicationController
   def create
     @thank = current_user.thanks.build(thank_params)
 
-    if @thank.tell_thank(current_user, thank_params[:receiver_id], thank_params[:group_id])
+    if @thank.save
       flash[:success] = "#{@thank.receiver.name} さんに感謝しました"
       redirect_to root_url
     else
@@ -16,9 +16,15 @@ class ThanksController < ApplicationController
   end
 
   def destroy
-    @thank.undo
-    flash[:warning] = '状態を元に戻しました'
-    redirect_to root_url
+    if @thank.destroy
+      flash[:warning] = '状態を元に戻しました'
+      redirect_to root_url
+    else
+      flash[:danger] = '状態を元に戻せませんでした'
+      @groups = current_user.groups.order(id: :desc).page(params[:page]).per(5)
+      @thanks = current_user.thanks.where.not(created_at: nil)
+      render 'toppages/index'
+    end
   end
 
   private

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -1,4 +1,7 @@
 class Thank < ApplicationRecord
+  before_save :send_thank?
+  before_destroy :undo?
+
   validates :content, presence: true, length: { maximum: 50 }
   belongs_to :user
   belongs_to :receiver, class_name: 'User'
@@ -15,21 +18,19 @@ class Thank < ApplicationRecord
   end
 
   # その日の感謝登録がない且つ、感謝する人とされる人が異なることを確認してから登録
-  def tell_thank(current_user, receiver_id, group_id)
+  def send_thank?
     # 該当group内で感謝を受けたuserのthanksに限定し取得。そのthankのcreated_atを日本日付形式にして新たな配列を作成。
-    thanks_to_receiver = current_user.thanks.where(receiver_id: receiver_id, group_id: group_id)
-    thank_days = thanks_to_receiver.map { |thank| thank_date = I18n.l thank.created_at }
+    thanks_received = self.user.thanks.where(receiver_id: self.receiver_id, group_id: self.group_id)
+    thank_days = thanks_received.map { |thank| thank_date = I18n.l thank.created_at }
 
     today = I18n.l Date.current
-    if !thank_days.include?(today) && self.user_id != receiver_id
-      self.save
-    end
+    true if !thank_days.include?(today) && self.user_id != self.receiver_id
   end
 
   # その日のデータか確認できれば、thank登録を元に戻す(削除する)
-  def undo
+  def undo?
     today = I18n.l Date.current
     thank_date = I18n.l self.created_at
-    self.destroy if today == thank_date
+    true if today == thank_date
   end
 end


### PR DESCRIPTION
why
コールバックを利用し、より効率的な処理にするため。

what
Thankの登録、削除処理の際に確認のためのメソッドをbefore_save, before_destroyを利用しコールバックで呼び出すようにした。