### PR TITLE
GroupUser登録失敗時の扱いにトランザクションを適用 #154

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,14 +8,18 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
 
-    if @group.save
-      @group_users = current_user.group_users.create(group_id: @group.id, permission: true)
+    # トランザクションを適用(グループの作成と中間テーブルの同時作成)
+    @group.transaction do
+      @group.save!
+      current_user.group_users.create!(group_id: @group.id, permission: true)
+    end
+    # 成功時の処理
       flash[:success] = '新しいグループを作成しました'
       redirect_to @group
-    else
+    rescue => e
+    # 失敗時の処理
       flash.now[:danger] = 'グループ作成に失敗しました'
       render :new
-    end
   end
 
   def show


### PR DESCRIPTION
why
現状なんらかの理由でGroupUserの登録に失敗した場合、無人のグループができてしまう可能性があるため。

what
新規グループ作成およびGroupUserの作成の際に、トランザクションを利用し、双方の作成が成功しなければ失敗となる扱いとした。