### PR TITLE
フラッシュメッセージ文言と表示方法を修正 #227

### DIFF
--- a/app/assets/stylesheets/_flash_message.scss
+++ b/app/assets/stylesheets/_flash_message.scss
@@ -1,0 +1,5 @@
+.alert-message-container {
+  width: 100%;
+  position: fixed;
+  opacity: 0.7;
+}

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -5,10 +5,10 @@ class ThanksController < ApplicationController
     @thank = current_user.thanks.build(thank_params)
 
     if @thank.save
-      flash[:success] = "#{@thank.receiver.name} さんに感謝しました"
+      flash[:success] = "#{@thank.receiver.name} さんに感謝を送りました"
       redirect_to root_url
     else
-      flash.now[:danger] = '感謝の登録に失敗しました'
+      flash.now[:danger] = '感謝の送信に失敗しました'
       @groups = current_user.groups.order(id: :desc).page(params[:page]).per(5)
       @thanks = current_user.thanks.where.not(created_at: nil)
       render 'toppages/index'
@@ -17,10 +17,10 @@ class ThanksController < ApplicationController
 
   def destroy
     if @thank.destroy
-      flash[:warning] = '状態を元に戻しました'
+      flash[:warning] = '送った感謝を取り消しました'
       redirect_to root_url
     else
-      flash[:danger] = '状態を元に戻せませんでした'
+      flash[:danger] = '感謝の取り消しに失敗しました'
       @groups = current_user.groups.order(id: :desc).page(params[:page]).per(5)
       @thanks = current_user.thanks.where.not(created_at: nil)
       render 'toppages/index'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,11 +10,11 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      flash[:success] = 'ユーザを登録しました'
+      flash[:success] = 'アカウントを登録しました'
       session[:user_id] = @user.id
       redirect_to root_url
     else
-      flash.now[:danger] = 'ユーザ登録に失敗しました'
+      flash.now[:danger] = 'アカウント登録に失敗しました'
       render :new
     end
   end

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>"><%= message %></div>
+  <div class="alert-message-container">
+    <div class="alert alert-<%= message_type %>"><%= message %></div>
+  </div>
 <% end %>


### PR DESCRIPTION
why
表示文言をより適切な内容にし、画面幅縮小時メッセージ表示のレイアウト崩れを修正をするため。

what
・コントローラにて文言を修正。
・フラッシュメッセージ要素に親要素を付与し、position: fixed;とopacityプロパティによりレイアウトと表示を修正。