### PR TITLE
グループ所属ユーザがいない場合の感謝登録フォームの表示を修正 #234

### DIFF
--- a/app/assets/javascripts/flash_message.js
+++ b/app/assets/javascripts/flash_message.js
@@ -16,7 +16,7 @@ document.addEventListener('turbolinks:load', () => {
     }, 30);
   }
 
-  // フラッシュメッセージがある場合にfadeOutFlashMsgを呼び出す
+  // flashMsgがある場合にfadeOutFlashMsgを呼び出す
   if (flashMsg !== null) {
     flashMsg.style.opacity = 0.7
     setTimeout(fadeOutFlashMsg, 3000);

--- a/app/assets/stylesheets/_group-container.scss
+++ b/app/assets/stylesheets/_group-container.scss
@@ -15,6 +15,7 @@
   text-align: center;
   margin-top: 50px;
   font-size: 18px;
+  color: $c-deep-gray;
 }
 
 .group-container {
@@ -23,6 +24,13 @@
   max-width: 850px;
   border-radius: 15px;
   box-shadow: 1px 1px 4px rgba(0, 0, 0, .7);
+
+  &__no-user-message {
+    text-align: center;
+    padding: 5px 0 10px 0;
+    font-size: 18px;
+    color: $c-deep-gray;
+  }
 }
 
 .group-name {

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -1,10 +1,10 @@
-<% if logged_in? %>
+<% if logged_in? %> <!-- ログイン時 -->
   <h1 class="header-message">１日１回、感謝を言葉に<i class="far fa-envelope"></i></h1>
-  <% if @groups == [] %>
-    <p class="no-group-message">
+  <% if @groups == [] %> <!-- 参加グループが存在しない時の表示 -->
+    <div class="no-group-message">
       参加グループがありません<br>
       グループを作成してユーザを招待しよう
-    </p>
+    </div>
   <% end %>
   <% @groups.each do |group| %>
     <% if permitted_group_user(current_user, group) %> <!--参加済みグループのみを表示!-->
@@ -12,6 +12,12 @@
         <div class="group-name">
           <%= link_to "#{group.name}", group_path(group) %>
         </div>
+        <% if group.users == [current_user] %> <!-- グループユーザがログインユーザのみの場合の表示 -->
+          <p class="group-container__no-user-message">
+            グループにユーザがいません<br>
+            ユーザを招待しましょう
+          </p>
+        <% else %>
           <% group.users.each do |user| %>
             <% if current_user != user && permitted_group_user(user, group) %> <!-- ログインユーザでない 且つ 参加済みユーザのみを表示 !-->
               <% if thank_today(@thanks, user, group) %> <!-- 今日の感謝登録あるかないかで表示内容を変更 !-->
@@ -33,12 +39,13 @@
               <% end %>
             <% end %>
           <% end %>
+        <% end %>
       </div>
     <% end %>
   <% end %>
   <%= paginate @groups %>
 
-<% else %>
+<% else %> <!-- 未ログイン時 -->
   <div class="account-header">
     ThanksHabitは<br>
     「感謝を伝える」を習慣化するアプリです


### PR DESCRIPTION
why
グループユーザがログインユーザのみの場合、ユーザが次にユーザ招待へと動作しやすいようするため。

what
グループユーザがログインユーザのみの場合のview表示をユーザを招待へ促すような表示に修正。