### PR TITLE
ゲストユーザでのログイン機能を実装 #240

### DIFF
--- a/app/assets/stylesheets/_account.scss
+++ b/app/assets/stylesheets/_account.scss
@@ -1,6 +1,7 @@
 @import "setup";
 
-// アカウント作成ページ、アカウント情報編集ページ双方に適用
+// アカウント作成ページ、アカウント情報編集ページ、ログインページに適用
+
 .account-header {
   font-size: 28px;
   margin: 25px auto;
@@ -13,6 +14,11 @@
   max-width: 450px;
   font-size: 17px;
   text-align: end;
+}
+
+// ゲストユーザログイン時、ユーザ情報編集ページボタン箇所メッセージ
+.unable-to-edit-message {
+  color: $c-pink;
 }
 
 // フォーム要素内
@@ -42,6 +48,30 @@
       &:hover {
         background-color: $c-light-blue;
         color: $c-deep-blue;
+      }
+    }
+  }
+}
+
+// ゲストユーザログインボタン
+.guest-account-form {
+  margin: 55px auto 15px;
+  width: 96%;
+  max-width: 450px;
+  font-size: 18px;
+
+  &__submit {
+    margin: 0 auto 15px;
+
+    &--btn {
+      width: 100%;
+      color: #fff;
+      background-color: $c-pink;
+      font-size: 18px;
+
+      &:hover {
+        background-color: $c-light-pink;
+        color: $c-pink;
       }
     }
   }

--- a/app/views/toppages/index.html.erb
+++ b/app/views/toppages/index.html.erb
@@ -50,7 +50,7 @@
     ThanksHabitは<br>
     「感謝を伝える」を習慣化するアプリです
   </div>
-  <%= form_with url: login_path, scope: :session, local: true, class: "account-form"  do |f| %>
+  <%= form_with url: login_path, scope: :session, local: true, class: "account-form" do |f| %>
     <div class="account-form__group">
       <%= f.label :email, 'メールアドレス', class: "account-form__group--label" %>
       <%= f.email_field :email, class: 'form-control' %>
@@ -64,6 +64,13 @@
     </div>
   <% end %>
   <div class="account-footer">
-    アカウントをお持ちでない方は <%= link_to 'こちら', signup_path %>
+    アカウント作成は <%= link_to 'こちら', signup_path %>
   </div>
+  <%= form_with url: login_path, scope: :session, local: true, class: "guest-account-form" do |f| %>
+    <%= f.hidden_field :email, value: "guest_user@mail.com" %>
+    <%= f.hidden_field :password, value: "guest_user" %>
+    <div class="guest-account-form__submit">
+      <%= f.submit 'ゲストユーザでアプリを体験する', class: 'btn guest-account-form__submit--btn' %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,7 +20,14 @@
     <%= f.label :password_confirmation, '確認用パスワード（8文字以上）', class: "account-form__group--label" %>
     <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
-  <div class="account-form__submit">
-    <%= f.submit '登録', class: 'btn account-form__submit--btn' %>
-  </div>
+
+  <% if user.email == "guest_user@mail.com" %>
+    <div class="unable-to-edit-message">
+      <i class="fas fa-exclamation-triangle"></i> ゲストユーザ情報は編集出来ません
+    </div>
+  <% else %>
+    <div class="account-form__submit">
+      <%= f.submit '登録', class: 'btn account-form__submit--btn' %>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
why
アカウントを作成せずにアプリを利用できるようにするため。

what
ログインフォーム下にゲストログインボタンを設置。合わせてゲストユーザログイン情報は編集不可とした。