### PR TITLE
application.scss の不要な記述を削除 #244

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,7 +24,3 @@
      padding-top: 60px;
    }
   }
-
-  @media screen and (max-width: 900px) {
-
-  }


### PR DESCRIPTION
why
明らかに必要ない不要な記述があったため。

what
scssの不要な記述を削除。