### PR TITLE
ゲストユーザでのグループ作成およびグループ名編集不可に #246

### DIFF
--- a/app/assets/stylesheets/_account.scss
+++ b/app/assets/stylesheets/_account.scss
@@ -19,6 +19,7 @@
 // ゲストユーザログイン時、ユーザ情報編集ページボタン箇所メッセージ
 .unable-to-edit-message {
   color: $c-pink;
+  margin-bottom: 10px;
 }
 
 // フォーム要素内

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -6,7 +6,13 @@
     <%= f.text_field :name, class: 'form-control' %>
   </div>
 
-  <div class="group-form__submit">
-    <%= f.submit '登録', class: "btn group-form__submit--btn" %>
-  </div>
+  <% if current_user.email == "guest_user@mail.com" %>
+    <div class="unable-to-edit-message">
+      <i class="fas fa-exclamation-triangle"></i> ゲストユーザでグループ作成、編集は出来ません
+    </div>
+  <% else %>
+    <div class="group-form__submit">
+      <%= f.submit '登録', class: "btn group-form__submit--btn" %>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
why
ゲストユーザでグループ作成および編集ができる仕様があまり好ましくないため。

what
viewで条件分岐させ、表示を切り替え、scssで表示レイアウトを微調整。